### PR TITLE
Drop appstream-compose command

### DIFF
--- a/org.kicad.KiCad.ODBCDriver.sqliteodbc.yml
+++ b/org.kicad.KiCad.ODBCDriver.sqliteodbc.yml
@@ -30,11 +30,6 @@ modules:
       - >
         install -Dm644 --target-directory=${FLATPAK_DEST}/share/metainfo \
           org.kicad.KiCad.ODBCDriver.sqliteodbc.metainfo.xml
-      - >
-        appstream-compose \
-          --basename=org.kicad.KiCad.ODBCDriver.sqliteodbc \
-          --prefix=${FLATPAK_DEST} \
-          --origin=flatpak org.kicad.KiCad.ODBCDriver.sqliteodbc
     sources:
       - type: archive
         strip-components: 2


### PR DESCRIPTION
This is done in preparation for FDO SDK 24.08, which will not provide this command anymore. Also according to official docs:

> Flatpak-builder (>= 1.3.4), can compose metadata for extensions
> automatically and it is no longer required to manually compose them
> through commands in the manifest.

(https://docs.flatpak.org/en/latest/extension.html#extension-manifest)